### PR TITLE
Fix undefined reference error when using alternative drawing sheets

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -5,7 +5,7 @@ Hooks.once("libWrapper.Ready", () => {
     libWrapper.register(MODULE_ID, "DrawingConfig.prototype._getSubmitData", function (wrapped, ...args) {
         const data = foundry.utils.flattenObject(wrapped(...args));
 
-        if (this.form.querySelector(`input[class="${MODULE_ID}--lineStyle-dash"]`).checked) {
+        if (this.form.querySelector(`input[class="${MODULE_ID}--lineStyle-dash"]`)?.checked) {
             data[`flags.${MODULE_ID}.lineStyle.dash`] = [
                 Number(data[`flags.${MODULE_ID}.lineStyle.dash`][0]) || 8,
                 Number(data[`flags.${MODULE_ID}.lineStyle.dash`][1]) || 5


### PR DESCRIPTION
I'm working on a module that uses an alternative sheet for some of my drawings. but I still want to have Advanced Drawing Module available for others. I noticed that when I try to submit changes from my sheet, I get null reference errors. I've previously noticed this when trying to use ADT with https://github.com/mordachai/investigation-board, for the same reason.

Turns out the fix is simple - there's one place with a jQuery check into the sheet `formData` response. Adding an optional chaining operator seems to fix it immediately. 

PR attached for your consideration!